### PR TITLE
Removes unnecessary path conversion

### DIFF
--- a/main.js
+++ b/main.js
@@ -232,20 +232,12 @@ function printCompletedMessage(themeName) {
  *  Once completed, send off the root JSON to be written to CSS.
  */
 function convertTheme(themeName, themePath, debug) {
-    var srcTheme = fs.readFileSync(__dirname + themePath, 'utf8');
+    var srcTheme = fs.readFileSync(themePath, 'utf8');
     parseTheme(srcTheme, function(theme) {
         extractStyles(themeName, theme);
         if (debug) print(root);
         writeFile(root, themeName, printCompletedMessage);
     });
-}
-
-
-/*******************************************************************************
- *  Helper function for cleaning up the beginning slash
- */
-function cleanPath(path) {
-    return '/' + path.replace(/^\//g, '');
 }
 
 
@@ -259,7 +251,7 @@ if (process.argv.length > 1) {
         process.exit(1);
     }
     var themeName = args[0];
-    var themePath = cleanPath(args[1]);
+    var themePath = args[1];
     var debug = args[2] ? true : false;
     convertTheme(themeName, themePath, debug);
 }


### PR DESCRIPTION
The path conversion in main.js does not allow absolute paths.
When I run something like the below, I get the error pasted at the bottom:
nodejs main.js "MyTheme" /home/user/Downloads/mytheme.tmTheme

The crucial point being it interprets the given (absolute) path as a relative one, and prepends the current path to give something like:
/home/user/codeMirror-aceEditor-theme-generator/home/user/Downloads/mytheme.tmTheme

To fix this we simply need to take out the prepend.
As a result we can also completely remove the whole cleanPath(..) function as all it does is normalise paths to have a "/" at the beginning of the string.

After applying the above we can run all variants of paths like:
nodejs main.js "MyTheme" /home/user/Downloads/mytheme.tmTheme
nodejs main.js "MyTheme" ~/Downloads/mytheme.tmTheme   # (This of course just expands to the above..)
nodejs main.js "MyTheme" ../Downloads/mytheme.tmTheme
nodejs main.js "MyTheme" mytheme.tmTheme

fs.js:432
  return binding.open(pathModule._makeLong(path), stringToFlags(flags), mode);
                 ^
Error: ENOENT, no such file or directory '/home/user/codeMirror-aceEditor-theme-generator/home/user/Downloads/mytheme.tmTheme'
    at Object.fs.openSync (fs.js:432:18)
    at Object.fs.readFileSync (fs.js:286:15)
    at convertTheme (/home/user/tmp/codeMirror-aceEditor-theme-generator/main.js:235:23)
    at Object.<anonymous> (/home/user/tmp/codeMirror-aceEditor-theme-generator/main.js:264:5)
    at Module._compile (module.js:456:26)
    at Object.Module._extensions..js (module.js:474:10)
    at Module.load (module.js:356:32)
    at Function.Module._load (module.js:312:12)
    at Function.Module.runMain (module.js:497:10)
    at startup (node.js:119:16)
