### PR TITLE
Changes require of CSSJSON to cssjson

### DIFF
--- a/main.js
+++ b/main.js
@@ -4,7 +4,7 @@
 var fs      = require('fs');
 var path    = require('path');
 var plist   = require('plist');
-var CSSJSON = require('CSSJSON');
+var cssjson = require('cssjson');
 
 
 /*******************************************************************************
@@ -52,7 +52,7 @@ function parseStyles(styles) {
  *  been written.
  */
 function writeFile(json, themeName, callback) {
-    var data = CSSJSON.toCSS(json);
+    var data = cssjson.toCSS(json);
     var themeName = themeName.toLowerCase().split(' ').join('-');
     var destination = __dirname+ '/' +themeName+ '.css'
 


### PR DESCRIPTION
Even after installing CSSJSON via 'npm install', I still get the below error.
The current CSSJSON package seems to install as 'cssjson' so changing the require to the new name allows the script to run again.

module.js:340
    throw err;
          ^
Error: Cannot find module 'CSSJSON'
    at Function.Module._resolveFilename (module.js:338:15)
    at Function.Module._load (module.js:280:25)
    at Module.require (module.js:364:17)
    at require (module.js:380:17)
    at Object.<anonymous> (/home/user/tmp/codeMirror-aceEditor-theme-generator/main.js:7:15)
    at Module._compile (module.js:456:26)
    at Object.Module._extensions..js (module.js:474:10)
    at Module.load (module.js:356:32)
    at Function.Module._load (module.js:312:12)
    at Function.Module.runMain (module.js:497:10)
